### PR TITLE
follow gofmt

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,11 @@ func main() {
 	})
 	sort.Slice(comments, func(i, j int) bool { return comments[i].Pos() < comments[j].Pos() })
 	f.Comments = comments
-	if err := printer.Fprint(os.Stdout, fset, f); err != nil {
+	p := printer.Config{
+		Mode:     printer.UseSpaces | printer.TabIndent,
+		Tabwidth: 8,
+	}
+	if err := p.Fprint(os.Stdout, fset, f); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Currently go-comments prints fields of struct with **tab**-separation:
```go
type a struct {
	x <tab> int
	y <tab> int
}
```

On the other hand, gofmt prints them with **space**-separation:
```go
type a struct {
	x <space> int
	y <space> int
}
```
See https://github.com/golang/go/blob/c9cc20bd3ad7ab68f620cb650376f1c01dc1167e/src/cmd/gofmt/gofmt.go#L39-L42

It would be nice that go-comments follows gofmt.